### PR TITLE
Fix argv having the wrong number of arguments in io.js

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 var command = require("./")('publish', 'unpublish', {
   r: 'registry',
   s: 'save'

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var minimist = require("minimist");
-var argv = minimist(process.argv.slice(process.argv[0] == 'node' ? 2 : 1));
+var argv = minimist(process.argv.slice(2));
 
 module.exports = command;
 module.exports.version = version;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "show-help": "2.x",
     "show-version": "1.x",
-    "minimist": "0.0.x"
+    "minimist": "^1.0.0"
   }
 }


### PR DESCRIPTION
Note: `iojs` or `node` will always be the first argument, regardless of how you call `./exmaple` or `node example`
